### PR TITLE
Fix data verbale interno 04-12-2024

### DIFF
--- a/02-RTB/documenti-interni/verbali/2024-12-04.typ
+++ b/02-RTB/documenti-interni/verbali/2024-12-04.typ
@@ -1,7 +1,7 @@
 #import "../../../lib/verbale.typ": *
 
 #show: body => verbale(
-  data: datetime(day: 06, month: 12, year: 2024),
+  data: datetime(day: 04, month: 12, year: 2024),
   tipo: [interno],
   versioni: (
     (


### PR DESCRIPTION
La data del verbale in copertina risultava aessere quella dell'ultima modifica e non la data della riunione