### PR TITLE
Fix verbale esterno 03-12-2024

### DIFF
--- a/02-RTB/documenti-esterni/verbali/2024-12-03.typ
+++ b/02-RTB/documenti-esterni/verbali/2024-12-03.typ
@@ -1,7 +1,7 @@
 #import "../../../lib/verbale.typ": *
 
 #show: body => verbale(
-  data: datetime(day: 06, month: 12, year: 2024),
+  data: datetime(day: 03, month: 12, year: 2024),
   tipo: [esterno],
   versioni: (
     (


### PR DESCRIPTION
La data in copertina è quella dell'ultima modifica, ma dovrebbe essere quella della riunione